### PR TITLE
Fix memory leakage

### DIFF
--- a/federator/integrationTest/transfer.js
+++ b/federator/integrationTest/transfer.js
@@ -1,5 +1,5 @@
-var Web3 = require('web3');
-var log4js = require('log4js');
+const Web3 = require('web3');
+const log4js = require('log4js');
 //configurations
 const config = require('../config/config.js');
 const abiBridge = require('../../abis/Bridge_v2.json');

--- a/federator/src/contracts/AllowTokensFactory.js
+++ b/federator/src/contracts/AllowTokensFactory.js
@@ -23,13 +23,13 @@ module.exports = class AllowTokensFactory extends ContractFactory {
     }
 
     async createInstance(web3, address) {
-        let allowTokensContract = this.getContractByAddressAndAbi(abiAllowTokensNew, address, web3);
+        let allowTokensContract = this.getContractByAbi(abiAllowTokensNew, address, web3);
         const version = await this.getVersion(allowTokensContract);
         const chainId = await utils.retry3Times(web3.eth.net.getId);
         if (version === 'v1') {
             return new IAllowTokensV1(allowTokensContract, chainId);
         } else if (version === 'v0') {
-            allowTokensContract = this.getContractByAddressAndAbi(abiAllowTokensOld, address, web3);
+            allowTokensContract = this.getContractByAbi(abiAllowTokensOld, address, web3);
             return new IAllowTokensV0(allowTokensContract, chainId);
         } else {
             throw Error('Unknown AllowTokens contract version');

--- a/federator/src/contracts/AllowTokensFactory.js
+++ b/federator/src/contracts/AllowTokensFactory.js
@@ -5,31 +5,31 @@ const IAllowTokensV1 = require('./IAllowTokensV1');
 const IAllowTokensV0 = require('./IAllowTokensV0');
 const CustomError = require('../lib/CustomError');
 const utils = require('../lib/utils');
+const ContractFactory = require('./ContractFactory');
 
-module.exports = class AllowTokensFactory {
+module.exports = class AllowTokensFactory extends ContractFactory {
     constructor(config, logger, Web3) {
-        this.config = config;
-        this.logger = logger;
-        this.mainWeb3 = new Web3(config.mainchain.host);
-        this.sideWeb3 = new Web3(config.sidechain.host);
+        super(config, logger, Web3);
+        this.mainChainBridgeContract = new this.mainWeb3.eth.Contract(abiBridge, this.config.mainchain.bridge);
+        this.sideChainBridgeContract = new this.sideWeb3.eth.Contract(abiBridge, this.config.sidechain.bridge);
     }
 
     async getVersion(allowTokensContract) {
         try {
             return await utils.retry3Times(allowTokensContract.methods.version().call);
-        } catch(err) {
+        } catch (err) {
             return 'v0';
         }
     }
 
     async createInstance(web3, address) {
-        let allowTokensContract = new web3.eth.Contract(abiAllowTokensNew, address);
+        let allowTokensContract = this.getContractByAddressAndAbi(abiAllowTokensNew, address, web3);
         const version = await this.getVersion(allowTokensContract);
         const chainId = await utils.retry3Times(web3.eth.net.getId);
         if (version === 'v1') {
             return new IAllowTokensV1(allowTokensContract, chainId);
         } else if (version === 'v0') {
-            allowTokensContract = new web3.eth.Contract(abiAllowTokensOld, address);
+            allowTokensContract = this.getContractByAddressAndAbi(abiAllowTokensOld, address, web3);
             return new IAllowTokensV0(allowTokensContract, chainId);
         } else {
             throw Error('Unknown AllowTokens contract version');
@@ -38,27 +38,24 @@ module.exports = class AllowTokensFactory {
 
     async getMainAllowTokensContract() {
         try {
-            const bridgeContract = new this.mainWeb3.eth.Contract(abiBridge, this.config.mainchain.bridge);
-            const allowTokensAddress = await utils.retry3Times(bridgeContract.methods.allowTokens().call);
+            const allowTokensAddress = await utils.retry3Times(this.mainChainBridgeContract.methods.allowTokens().call);
             return await this.createInstance(
                 this.mainWeb3,
                 allowTokensAddress
             );
-        } catch(err) {
+        } catch (err) {
             throw new CustomError(`Exception creating Main AllowTokens Contract`, err);
         }
     }
 
     async getSideAllowTokensContract() {
         try {
-            const bridgeContract = new this.sideWeb3.eth.Contract(abiBridge, this.config.sidechain.bridge);
-            const allowTokensAddress = await utils.retry3Times(bridgeContract.methods.allowTokens().call);
-
+            const allowTokensAddress = await utils.retry3Times(this.sideChainBridgeContract.methods.allowTokens().call);
             return await this.createInstance(
                 this.sideWeb3,
                 allowTokensAddress
             );
-        } catch(err) {
+        } catch (err) {
             throw new CustomError(`Exception creating Side AllowTokens Contract`, err);
         }
     }

--- a/federator/src/contracts/BridgeFactory.js
+++ b/federator/src/contracts/BridgeFactory.js
@@ -16,10 +16,10 @@ module.exports = class BridgeFactory extends ContractFactory {
     }
 
     async createInstance(web3, address) {
-        let bridgeContract = this.getContractByAddressAndAbi(abiBridgeOld, address, web3);
+        let bridgeContract = this.getContractByAbi(abiBridgeOld, address, web3);
         const version = await this.getVersion(bridgeContract);
         if (version === 'v3') {
-            bridgeContract = this.getContractByAddressAndAbi(abiBridgeNew, address, web3);
+            bridgeContract = this.getContractByAbi(abiBridgeNew, address, web3);
         } else if (!['v2', 'v1'].includes(version)) {
             throw Error('Unknown Bridge contract version');
         }

--- a/federator/src/contracts/BridgeFactory.js
+++ b/federator/src/contracts/BridgeFactory.js
@@ -3,14 +3,12 @@ const abiBridgeNew = require('../../../abis/Bridge.json');
 const BridgeInterface = require('./IBridge.js');
 const CustomError = require('../lib/CustomError');
 const utils = require('../lib/utils');
+const ContractFactory = require('./ContractFactory');
 
-module.exports = class BridgeFactory {
+module.exports = class BridgeFactory extends ContractFactory {
 
     constructor(config, logger, Web3) {
-        this.config = config;
-        this.logger = logger;
-        this.mainWeb3 = new Web3(config.mainchain.host);
-        this.sideWeb3 = new Web3(config.sidechain.host);
+        super(config, logger, Web3);
     }
 
     async getVersion(bridgeContract) {
@@ -18,11 +16,11 @@ module.exports = class BridgeFactory {
     }
 
     async createInstance(web3, address) {
-        let bridgeContract = new web3.eth.Contract(abiBridgeOld, address);
+        let bridgeContract = this.getContractByAddressAndAbi(abiBridgeOld, address, web3);
         const version = await this.getVersion(bridgeContract);
         if (version === 'v3') {
-            bridgeContract = new web3.eth.Contract(abiBridgeNew, address);
-        } else if (!['v2','v1'].includes(version)) {
+            bridgeContract = this.getContractByAddressAndAbi(abiBridgeNew, address, web3);
+        } else if (!['v2', 'v1'].includes(version)) {
             throw Error('Unknown Bridge contract version');
         }
         return new BridgeInterface(bridgeContract);
@@ -34,7 +32,7 @@ module.exports = class BridgeFactory {
                 this.mainWeb3,
                 this.config.mainchain.bridge
             );
-        } catch(err) {
+        } catch (err) {
             throw new CustomError(`Exception creating Main Bridge Contract`, err);
         }
     }
@@ -45,7 +43,7 @@ module.exports = class BridgeFactory {
                 this.sideWeb3,
                 this.config.sidechain.bridge
             );
-        } catch(err) {
+        } catch (err) {
             throw new CustomError(`Exception creating Side Bridge Contract`, err);
         }
     }

--- a/federator/src/contracts/ContractFactory.js
+++ b/federator/src/contracts/ContractFactory.js
@@ -1,0 +1,21 @@
+module.exports = class ContractFactory {
+    constructor(config, logger, Web3) {
+        this.config = config;
+        this.logger = logger;
+        this.mainWeb3 = new Web3(config.mainchain.host);
+        this.sideWeb3 = new Web3(config.sidechain.host);
+        this.contractsByAddressAndAbi = new Map();
+    }
+
+    getContractByAddressAndAbi(abi, address, web3) {
+        if (!this.contractsByAddressAndAbi.has(abi)) {
+            this.contractsByAddressAndAbi.set(abi, new Map());
+        }
+        let contractsByAddressForAbi = this.contractsByAddressAndAbi.get(abi)
+        if (!contractsByAddressForAbi.has(address)) {
+            const contract = new web3.eth.Contract(abi, address);
+            contractsByAddressForAbi.set(address, contract);
+        }
+        return this.contractsByAddressAndAbi.get(abi).get(address);
+    }
+}

--- a/federator/src/contracts/ContractFactory.js
+++ b/federator/src/contracts/ContractFactory.js
@@ -4,18 +4,16 @@ module.exports = class ContractFactory {
         this.logger = logger;
         this.mainWeb3 = new Web3(config.mainchain.host);
         this.sideWeb3 = new Web3(config.sidechain.host);
-        this.contractsByAddressAndAbi = new Map();
+        this.contractsByAbi = new Map();
     }
 
-    getContractByAddressAndAbi(abi, address, web3) {
-        if (!this.contractsByAddressAndAbi.has(abi)) {
-            this.contractsByAddressAndAbi.set(abi, new Map());
+    // There should only be one address per abi - the address is only needed to create a new web3.eth.Contract object.
+    getContractByAbi(abi, address, web3) {
+        let contractForAbi = this.contractsByAbi.get(abi)
+        if (!contractForAbi) {
+            contractForAbi = new web3.eth.Contract(abi, address);
+            this.contractsByAbi.set(abi, contractForAbi);
         }
-        let contractsByAddressForAbi = this.contractsByAddressAndAbi.get(abi)
-        if (!contractsByAddressForAbi.has(address)) {
-            const contract = new web3.eth.Contract(abi, address);
-            contractsByAddressForAbi.set(address, contract);
-        }
-        return this.contractsByAddressAndAbi.get(abi).get(address);
+        return contractForAbi;
     }
 }

--- a/federator/src/contracts/FederationFactory.js
+++ b/federator/src/contracts/FederationFactory.js
@@ -5,25 +5,24 @@ const FederationInterfaceV1 = require('./IFederationV1.js');
 const FederationInterfaceV2 = require('./IFederationV2.js');
 const CustomError = require('../lib/CustomError');
 const utils = require('../lib/utils');
+const ContractFactory = require('./ContractFactory');
 
-module.exports = class FederationFactory {
+module.exports = class FederationFactory extends ContractFactory {
 
     constructor(config, logger, Web3) {
-        this.config = config;
-        this.logger = logger;
-        this.mainWeb3 = new Web3(config.mainchain.host);
-        this.sideWeb3 = new Web3(config.sidechain.host);
+        super(config, logger, Web3)
+        this.mainChainBridgeContract = new this.mainWeb3.eth.Contract(abiBridge, this.config.mainchain.bridge);
+        this.sideChainBridgeContract = new this.sideWeb3.eth.Contract(abiBridge, this.config.sidechain.bridge);
     }
 
     async createInstance(web3, address) {
-        let federationContract = new web3.eth.Contract(abiFederationNew, address);
+        let federationContract = this.getContractByAddressAndAbi(abiFederationNew, address, web3);
         const version = await this.getVersion(federationContract);
 
         if (version === 'v2') {
-            federationContract = new web3.eth.Contract(abiFederationNew, address);
             return new FederationInterfaceV2(this.config, federationContract);
         } else if (version === 'v1') {
-            federationContract = new web3.eth.Contract(abiFederationOld, address);
+            federationContract = this.getContractByAddressAndAbi(abiFederationOld, address, web3);
             return new FederationInterfaceV1(this.config, federationContract);
         } else {
             throw Error('Unknown Federation contract version');
@@ -40,8 +39,7 @@ module.exports = class FederationFactory {
 
     async getMainFederationContract() {
         try {
-            const bridgeContract = new this.mainWeb3.eth.Contract(abiBridge, this.config.mainchain.bridge);
-            const federationAddress = await utils.retry3Times(bridgeContract.methods.getFederation().call);
+            const federationAddress = await utils.retry3Times(this.mainChainBridgeContract.methods.getFederation().call);
             return await this.createInstance(
                 this.mainWeb3,
                 federationAddress
@@ -53,8 +51,7 @@ module.exports = class FederationFactory {
 
     async getSideFederationContract() {
         try {
-            const bridgeContract = new this.sideWeb3.eth.Contract(abiBridge, this.config.sidechain.bridge);
-            const federationAddress = await utils.retry3Times(bridgeContract.methods.getFederation().call);
+            const federationAddress = await utils.retry3Times(this.sideChainBridgeContract.methods.getFederation().call);
             return await this.createInstance(
                 this.sideWeb3,
                 federationAddress

--- a/federator/src/contracts/FederationFactory.js
+++ b/federator/src/contracts/FederationFactory.js
@@ -16,13 +16,13 @@ module.exports = class FederationFactory extends ContractFactory {
     }
 
     async createInstance(web3, address) {
-        let federationContract = this.getContractByAddressAndAbi(abiFederationNew, address, web3);
+        let federationContract = this.getContractByAbi(abiFederationNew, address, web3);
         const version = await this.getVersion(federationContract);
 
         if (version === 'v2') {
             return new FederationInterfaceV2(this.config, federationContract);
         } else if (version === 'v1') {
-            federationContract = this.getContractByAddressAndAbi(abiFederationOld, address, web3);
+            federationContract = this.getContractByAbi(abiFederationOld, address, web3);
             return new FederationInterfaceV1(this.config, federationContract);
         } else {
             throw Error('Unknown Federation contract version');

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -109,10 +109,10 @@ module.exports = class Federator {
         const numberOfPages = Math.ceil((toBlock - fromBlock) / recordsPerPage);
         this.logger.debug(`Total pages ${numberOfPages}, blocks per page ${recordsPerPage}`);
 
-        var fromPageBlock = fromBlock;
-        for(var currentPage = 1; currentPage <= numberOfPages; currentPage++) {
-            var toPagedBlock = fromPageBlock + recordsPerPage-1;
-            if(currentPage == numberOfPages) {
+        let fromPageBlock = fromBlock;
+        for (let currentPage = 1; currentPage <= numberOfPages; currentPage++) {
+            let toPagedBlock = fromPageBlock + recordsPerPage - 1;
+            if (currentPage === numberOfPages) {
                 toPagedBlock = toBlock
             }
             this.logger.debug(`Page ${currentPage} getting events from block ${fromPageBlock} to ${toPagedBlock}`);

--- a/federator/src/lib/Heartbeat.js
+++ b/federator/src/lib/Heartbeat.js
@@ -101,10 +101,10 @@ module.exports = class Heartbeat {
                 const numberOfPages = Math.ceil((toBlock - fromBlock) / recordsPerPage);
                 this.logger.debug(`Total pages ${numberOfPages}, blocks per page ${recordsPerPage}`);
 
-                var fromPageBlock = fromBlock;
-                for(var currentPage = 1; currentPage <= numberOfPages; currentPage++) {
-                    var toPagedBlock = fromPageBlock + recordsPerPage-1;
-                    if(currentPage == numberOfPages) {
+                let fromPageBlock = fromBlock;
+                for(let currentPage = 1; currentPage <= numberOfPages; currentPage++) {
+                    let toPagedBlock = fromPageBlock + recordsPerPage - 1;
+                    if(currentPage === numberOfPages) {
                         toPagedBlock = toBlock
                     }
 

--- a/federator/src/lib/Heartbeat.js
+++ b/federator/src/lib/Heartbeat.js
@@ -150,7 +150,6 @@ module.exports = class Heartbeat {
 
         try {
             for(let log of logs) {
-                this.logger.info('Processing Heartbeat event log:', log);
 
                 const {
                     blockNumber

--- a/federator/src/lib/utils.js
+++ b/federator/src/lib/utils.js
@@ -23,11 +23,9 @@ const Web3 = require('web3');
     for (let i = 0; i < retriesMax; i++) {
         try {
             if (!config.isCb) {
-                const val = await fn.apply(null, args);
-                return val;
+                return await fn.apply(null, args);
             } else {
-                const val = await getPromise(fn, clone(args));
-                return val;
+                return await getPromise(fn, clone(args));
             }
         } catch (error) {
             if(retriesMax === i+1 || (error.hasOwnProperty('retryable') && !error.retryable)) throw error;
@@ -44,11 +42,11 @@ async function retry3Times(func, params = null) {
 }
 
 async function waitBlocks(client, numberOfBlocks) {
-    var startBlock = await client.eth.getBlockNumber();
-    var currentBlock = startBlock;
+    const startBlock = await client.eth.getBlockNumber();
+    let currentBlock = startBlock;
     while(numberOfBlocks > currentBlock - startBlock) {
-        var newBlock = await client.eth.getBlockNumber();
-        if(newBlock != currentBlock){
+        const newBlock = await client.eth.getBlockNumber();
+        if(newBlock !== currentBlock){
             currentBlock = newBlock;
         } else {
             await sleep(20000);
@@ -171,13 +169,13 @@ async function asyncMine(anotherWeb3Instance = null) {
                 return resolve(result);
             });
     });
-};
+}
 
 async function evm_mine(iterations, web3Instance = null) {
-    for(var i = 0; i < iterations; i++ ) {
+    for(let i = 0; i < iterations; i++ ) {
         await asyncMine(web3Instance);
-    };
-};
+    }
+}
 
 
 function increaseTimestamp(web3, increase) {

--- a/federator/test/TransactionSender.test.js
+++ b/federator/test/TransactionSender.test.js
@@ -13,7 +13,7 @@ const logger = {
     warn: jest.fn(),
     error: jest.fn(),
 };
-var web3Mock = jest.fn();
+const web3Mock = jest.fn();
 
 describe('TransactionSender module tests', () => {
     beforeEach(async function () {

--- a/federator/test/web3Mock/eth.js
+++ b/federator/test/web3Mock/eth.js
@@ -1,6 +1,6 @@
 const contractMapping = require('./contractMapping');
 const defaults = require('./defaults');
-var Web3PromiEvent = require('web3-core-promievent');
+const Web3PromiEvent = require('web3-core-promievent');
 
 let eth = {};
 
@@ -10,8 +10,8 @@ eth.getTransactionCount = () => defaults.data.ethTransactionCount;
 eth.getGasPrice = () => defaults.data.gasPrice;
 
 let promiseSend = function(){
-    var promiEvent = Web3PromiEvent();
-    
+    const promiEvent = Web3PromiEvent();
+
     setTimeout(function() {
         promiEvent.eventEmitter.emit('transactionHash', defaults.data.receipt.transactionHash);
         promiEvent.resolve(defaults.data.receipt);


### PR DESCRIPTION
Many validators claimed that 2G ram is not sufficient although the script for running a validator node is a simple javascript code.

Assuming that web3 library was the problem we are trying to fetch some commits from upstream to solve the problem.